### PR TITLE
Specify exact version of wasm-bindgen-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Running
 
-Install `wasm-bindgen-cli` (if you haven't already):
+Install `wasm-bindgen-cli` (if you haven't already). Currently it is required to install the same version that is referred to in the sample's Cargo.toml file, which is currently 0.2.25:
 
-    $ cargo install wasm-bindgen-cli
+    $ cargo install wasm-bindgen-cli --version 0.2.25
 
 From this directory, run either `make`, or if you don't have `make` or want
 to do it manually, run:


### PR DESCRIPTION
The Cargo.toml file defined a dependency on wasm-bindgen = "0.2.25", but the latest available that gets installed is 0.2.29 and then the wasm bindgen fails as it requires the versions match excactly, so specify the version when installing it.